### PR TITLE
added hook function groups

### DIFF
--- a/flex_model/core/wrapper.py
+++ b/flex_model/core/wrapper.py
@@ -9,11 +9,13 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
+    Collection,
     Dict,
     Generator,
     Iterator,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -59,13 +61,170 @@ class _SharedState:
     offload_mode: str
 
 
+class _HookFunctionGroupManager:
+    def __init__(self):
+        self.hook_fn_to_groups_map = defaultdict(set)
+        self.groups = set()
+
+    def get_hook_fn_groups(self, hook_fn: HookFunction) -> Set[str]:
+        return self.hook_fn_to_groups_map[hook_fn]
+
+    def get_group_hook_fns(self, group_name: str) -> List[HookFunction]:
+        hook_fns = []
+        for hook_fn, groups in self.hook_fn_to_groups_map.items():
+            if group_name in groups:
+                hook_fns.append(hook_fn)
+        return hook_fns
+
+    def create(
+        self,
+        group_name: str,
+        group_constructor: str,
+        expected_shape: Tuple[Optional[int], ...],
+        all_names: List[str],
+        editing_function: Optional[Callable] = None,
+        unpack_idx: int = 0,
+    ) -> List[HookFunction]:
+        """Instantiate and group hook functions based on module name pattern matching."""
+        matching_modules = []
+        for module_name in all_names:
+            if group_constructor in module_name:
+                matching_modules.append(module_name)
+
+        hook_fns = []
+        for mod_name in matching_modules:
+            hf = HookFunction(
+                module_name=mod_name,
+                expected_shape=expected_shape,
+                editing_function=editing_function,
+                unpack_idx=unpack_idx,
+            )
+            self.hook_fn_to_groups_map[hf].add(group_name)
+            hook_fns.append(hf)
+
+        if group_name not in self.groups:
+            self.groups.add(group_name)
+
+        return hook_fns
+
+    @functools.singledispatchmethod
+    def update(self, group_constructor, group_name) -> None:
+        raise NotImplementedError(f"Cannot make group using: {type(group_constructor)}")
+
+    @update.register
+    def _update_by_list_hook_fns(
+        self, group_constructor: list, group_name: str
+    ) -> None:
+        """Add group tag to a collection of hook functions."""
+        are_hook_fns = map(lambda x: isinstance(x, HookFunction), group_constructor)
+        assert all(are_hook_fns), f"set_group takes a collection of only HookFunctions"
+
+        # Associate the hook functions with this group.
+        for hook_fn in group_constructor:
+            self.hook_fn_to_groups_map[hook_fn].add(group_name)
+
+        if group_name not in self.groups:
+            self.groups.add(group_name)
+
+    @update.register
+    def _update_by_hook_fn(
+        self, group_constructor: HookFunction, group_name: str
+    ) -> None:
+        """Add a group tag to a single hook function."""
+        self.hook_fn_to_groups_map[group_constructor].add(group_name)
+
+        if group_name not in self.groups:
+            self.groups.add(group_name)
+
+    @update.register
+    def _update_by_string(self, group_constructor: str, group_name: str) -> None:
+        """Pattern-match existing hook functions using group constrcutor."""
+        hook_functions_to_add = []
+        for hook_fn, groups in self.hook_fn_to_groups_map.items():
+            if group_constructor in hook_fn.module_name:
+                hook_functions_to_add.append(hook_fn)
+
+        # Associate the hook functions with this group.
+        for hook_fn in hook_functions_to_add:
+            self.hook_fn_to_groups_map[hook_fn].add(group_name)
+
+        if group_name not in self.groups:
+            self.groups.add(group_name)
+
+    def _is_group_alive(self, group_name: str) -> bool:
+        """A group is alive if it has one or more associated hook functions."""
+        return any(
+            map(lambda gs: group_name in gs, list(self.hook_fn_to_groups_map.values()))
+        )
+
+    @functools.singledispatchmethod
+    def remove(self, group_constructor, group_name) -> None:
+        raise NotImplementedError
+
+    @remove.register
+    def _remove_by_list_hook_fns(
+        self, group_constructor: list, group_name: str
+    ) -> None:
+        are_hook_fns = map(lambda x: isinstance(x, HookFunction), group_constructor)
+        assert all(are_hook_fns), f"set_group takes a collection of only HookFunctions"
+        assert group_name != "all", "Can't remove 'all' group references"
+
+        for hook_fn in group_constructor:
+            self.hook_fn_to_groups_map[hook_fn].remove(group_name)
+
+        if not self._is_group_alive(group_name):
+            self.groups.remove(group_name)
+
+    @remove.register
+    def _remove_by_hook_fn(
+        self, group_constructor: HookFunction, group_name: str
+    ) -> None:
+        self.hook_fn_to_groups_map[group_constructor].remove(group_name)
+
+        if not self._is_group_alive(group_name):
+            self.groups.remove(group_name)
+
+    @remove.register
+    def _remove_by_string(self, group_constructor: str, group_name: str) -> None:
+        hook_functions_to_remove = []
+        for hook_fn, groups in self.hook_fn_to_groups_map.items():
+            if group_constructor in hook_fn.module_name:
+                hook_functions_to_remove.append(hook_fn)
+
+        for hook_fn in hook_functions_to_remove:
+            self.hook_fn_to_groups_map[hook_fn].remove(group_name)
+
+        if not self._is_group_alive(group_name):
+            self.groups.remove(group_name)
+
+    def bisect(self, active_group_names: Union[str, List[str]]) -> Set[HookFunction]:
+        """Separate all hook functions into active/inactive sets."""
+        if isinstance(active_group_names, str):
+            active_group_names = [active_group_names]
+        active_group_names = set(active_group_names)
+
+        # A hook function is active if its intersection with the requested
+        # active groups is nonzero.
+        active_hook_fns = set()
+        inactive_hook_fns = set()
+        for hook_fn, groups in self.hook_fn_to_groups_map.items():
+            if not groups.isdisjoint(active_group_names):
+                active_hook_fns.add(hook_fn)
+            else:
+                inactive_hook_fns.add(hook_fn)
+
+        # Sanity check: Hook functions belong to only one group.
+        assert active_hook_fns.isdisjoint(inactive_hook_fns)
+
+        return active_hook_fns, inactive_hook_fns
+
+
 def _finalize_dangling_state(hook_functions) -> None:
     """Clear persistent state when FlexModel is garbage collected."""
     # Remove hook functions from model.
-    for group_name, module_to_hf in hook_functions.items():
-        for m, hf_to_handle in module_to_hf.items():
-            for hf, handle in hf_to_handle.items():
-                handle.remove()
+    for m, hf_to_handle in hook_functions.items():
+        for hf, handle in hf_to_handle.items():
+            handle.remove()
     hook_functions.clear()
 
     # Clear distributed states.
@@ -178,9 +337,8 @@ class FlexModel(nn.Module):
         """
         super().__init__()
         self.module = module
-        self.hook_functions: Dict[
-            nn.Module, Dict[HookFunction, torch.utils.hooks.RemovableHandle]
-        ] = {"all": defaultdict(dict)}
+
+        # Map: submodule -> hook functions -> hook handle.
         self.output_ptr = output_ptr
         self.save_ctx: Namespace = Namespace()  # dumb Namespace for now
         self.trainable_modules = nn.ModuleDict()
@@ -204,6 +362,7 @@ class FlexModel(nn.Module):
         self._shared_state = _SharedState(
             self.output_ptr, self.save_ctx, self.trainable_modules, self.offload_mode,
         )
+        self._hook_fn_group_manager = _HookFunctionGroupManager()
 
         # Initialize mappings.
         self._hook_type_to_pt_attr = {
@@ -213,32 +372,76 @@ class FlexModel(nn.Module):
             "forward_pre": "register_forward_pre_hook",
             "backward_pre": "register_full_backward_pre_hook",
         }
+        self._module_to_hook_fns_map: Dict[
+            Union[nn.Module, Tensor],
+            Dict[HookFunction, torch.utils.hooks.RemovableHandle],
+        ] = defaultdict(dict)
 
+        # Setup finalizer for cleanup.
         self._finalizer = weakref.finalize(
-            self, _finalize_dangling_state, self.hook_functions,
+            self, _finalize_dangling_state, self._module_to_hook_fns_map,
         )
 
-    def restore(self) -> nn.Module:
-        """Cleans up dangling states and modifications to wrapped module."""
-        self._finalizer()
-        return self.module
+    def _enable_hooks(self, active_hooks: Set[HookFunction]):
+        """Sink selected hooks into associated submodules."""
+        for module, hook_fn_to_handle in self._module_to_hook_fns_map.items():
+            for hook_fn, handle in hook_fn_to_handle.items():
+                if handle is None and hook_fn in active_hooks:
+                    self._register_hook_impl(module, hook_fn)
 
-    @functools.singledispatchmethod
-    def _make_group(self, group_constructor):
-        raise NotImplementedError(f"Cannot make group using: {group_constructor}")
+    def _disable_hooks(self, hooks: Set[HookFunction]):
+        """Pull selected hooks out of associated submodules."""
+        for module, hook_fn_to_handle in self._module_to_hook_fns_map.items():
+            for hook_fn, handle in hook_fn_to_handle.items():
+                if handle is not None and hook_fn in hooks:
+                    handle.remove()
+                    self._module_to_hook_fns_map[module][hook_fn] = None
 
-    @_make_group.register
-    def _(self, group_constructor: str):
-        # TODO: Pattern match module names for already-registered hook functions.
-        raise NotImplementedError
+    def _flush_pipeline(self) -> None:
+        """Gather tensors from all pipeline stages to the first stage."""
+        if (
+            torch.distributed.is_initialized()
+            and dist.in_pipeline_parallel_group()
+            and dist.get_activation_pipeline_parallel_world_size() > 1
+        ):
+            gathered_acts = dist.gather_pipeline_parallel_tensor_dicts(self.output_ptr)
 
-    @_make_group.register
-    def _(self, group_constructor: list, group_alias: str):
-        # TODO: Construct group explicitly using hook functions.
-        raise NotImplementedError
+            # Rank 0 accumulates the activation tensors.
+            if dist.get_activation_pipeline_parallel_rank() == 0:
+                self.output_ptr.update(gathered_acts)
+
+            # Other ranks reset their collections for the next forward pass.
+            else:
+                self.output_ptr = {}
+
+    def forward(
+        self,
+        *args,
+        groups: Union[str, List[str]] = "all",
+        complement: bool = False,
+        **kwargs,
+    ) -> Any:
+        """Run a forward pass of the model with hooks enabled by default."""
+        active, inactive = self._hook_fn_group_manager.bisect(groups)
+
+        if not complement:
+            self._enable_hooks(active)
+            self._disable_hooks(inactive)
+        else:
+            self._enable_hooks(inactive)
+            self._disable_hooks(active)
+
+        outputs = self.module(*args, **kwargs)
+
+        # Post-forward cleanup.
+        self._flush_pipeline()
+
+        return outputs
 
     def _register_hook_impl(self, hook_function: HookFunction) -> None:
-        """Registers hook to underlying pytorch module."""
+        """Pytorch `nn.Module` hook function registration implementation."""
+        # TODO: `get_module` should work with the parameter tensors in the case
+        #       of `register_hook(Tensor)`. Needs verification.
         module = _get_module(self.module, hook_function.module_name)
 
         # Register hook function to pt module.
@@ -246,9 +449,12 @@ class FlexModel(nn.Module):
             module, self._hook_type_to_pt_attr[hook_function._hook_type], None
         )
         handle = register_fn(hook_function)
-        self.hook_functions["all"][module][hook_function] = handle
 
-    def _hook_registration_prologue(
+        # All registered hooks are members of the "all" hook function group.
+        self._module_to_hook_fns_map[module][hook_function] = handle
+        self._hook_fn_group_manager.update(hook_function, "all")
+
+    def _register_hook_prologue(
         self, hook_function: HookFunction, hook_type: str
     ) -> None:
         """Validate hook function and set state."""
@@ -274,82 +480,135 @@ class FlexModel(nn.Module):
         # Pass to registration impl.
         self._register_hook_impl(hook_function)
 
+    def get_hook_function_groups(self, hook_function: HookFunction):
+        """Get a collection of groups that the `hook_function` belongs to.
+
+        :param HookFunction hook_function: `HookFunction` to fetch related
+            groups.
+        """
+        return self._hook_fn_group_manager.get_hook_fn_groups(hook_function)
+
+    def get_group_hook_functions(self, group_name: str):
+        """Get a collection of `HookFunction`s that belong in the given group.
+
+        :param str group_name: Group to fetch related `HookFunction`s from.
+        """
+        return self._hook_fn_group_manager.get_group_hook_fns(group_name)
+
+    def update_hook_groups(
+        self,
+        group_constructor: Union[List[HookFunction], HookFunction, str],
+        group_name: str,
+    ) -> None:
+        """Adds a group reference to a set of `HookFunction`s.
+
+        `group_constructor` can be one of three things:
+            1. List of `HookFunction`s to add the group to.
+            2. A single `HookFunction` to add the group to.
+            3. A string pattern to match against `HookFunction`s `module_name`
+                attributes. The matching `HookFunction`s will have the group
+                reference added.
+
+        :param group_constructor: See above note.
+        :type group_constructor: Union[List[HookFunction], HookFunction, str]
+        :param str group_name: Name of the group to add.
+        """
+        self._hook_fn_group_manager.update(group_constructor, group_name)
+
+    def remove_hook_groups(
+        group_constructor: Union[List[HookFunction], HookFunction, str],
+        group_name: str,
+    ) -> None:
+        """Removes a group reference from a set of `HookFunction`s.
+
+        `group_constructor` can be one of three things:
+            1. List of `HookFunction`s to remove the group from.
+            2. A single `HookFunction` to remove the group from.
+            3. A string pattern to match against `HookFunction`s `module_name`
+                attributes. The matching `HookFunction`s will have the group
+                reference removed.
+
+        :param group_constructor: See above note.
+        :type group_constructor: Union[List[HookFunction], HookFunction, str]
+        :param str group_name: Name of the group to remove.
+        """
+        self._hook_fn_group_manager.remove(group_constructor, group_name)
+
+    def create_hook_group(
+        self,
+        group_name: str,
+        group_constructor: str,
+        expected_shape: Tuple[Optional[int], ...],
+        editing_function: Optional[Callable] = None,
+        unpack_idx: Optional[int] = 0,
+        hook_type: str = "forward",
+    ) -> None:
+        """Create a group of HookFunctions.
+
+        Instantiates a collection of `HookFunction`s according to the provided
+        arguments (broadcast). Adds the instantiated `HookFunction`s to a
+        group.
+
+        :param str group_name: Group name to assign.
+        :param str group_constructor: String pattern to match module/parameter
+            names as the `module_name` parameter for creating the
+            `HookFunction`s.
+        :param expected_shape: Expected shape of the activations.
+        :param Callable editing_function: Editing function to apply on each
+            `HookFunction`.
+        :param int unpack_idx: Index of tensor in module outputs.
+        :param str hook_type: Type of pytorch hook to use.
+        """
+        if hook_type == "tensor":
+            all_names = [n for n, _ in self.module.named_parameters()]
+        else:
+            all_names = ([n for n, _ in self.module.named_modules()],)
+        hook_fns = self._hook_fn_group_manager.create(
+            group_name,
+            group_constructor,
+            expected_shape,
+            all_names,
+            editing_function,
+            unpack_idx,
+        )
+
+        for hf in hook_fns:
+            self._register_hook_prologue(hf, hook_type)
+
     def register_forward_hook(self, hook_function: HookFunction) -> None:
         """Register a forward hook function.
 
         :param HookFunction hook_function: `HookFunction` instance to register.
         """
-        self._hook_registration_prologue(hook_function, "forward")
+        self._register_hook_prologue(hook_function, "forward")
 
     def register_full_backward_hook(self, hook_function: HookFunction) -> None:
         """Register a backward hook function.
 
         :param HookFunction hook_function: `HookFunction` instance to register.
         """
-        self._hook_registration_prologue(hook_function, "full_backward")
+        self._register_hook_prologue(hook_function, "full_backward")
 
     def register_hook(self, hook_function: HookFunction) -> None:
         """Register a backward hook function on a tensor.
 
         :param HookFunction hook_function: `HookFunction` instance to register.
         """
-        self._hook_registration_prologue(hook_function, "tensor")
+        self._register_hook_prologue(hook_function, "tensor")
 
     def register_forward_pre_hook(self, hook_function: HookFunction) -> None:
         """Register a pre-forward hook function.
 
         :param HookFunction hook_function: `HookFunction` instance to register.
         """
-        self._hook_registration_prologue(hook_function, "forward_pre")
+        self._register_hook_prologue(hook_function, "forward_pre")
 
     def register_full_backward_pre_hook(self, hook_function: HookFunction) -> None:
         """Register a pre-backward hook function.
 
         :param HookFunction hook_function: `HookFunction` instance to register.
         """
-        self._hook_registration_prologue(hook_function, "backward_pre")
-
-    def _enable_group_hooks(self, group: str):
-        for m, hook_fn_to_handle in self.hook_functions[group].items():
-            for hook_fn, handle in hook_fn_to_handle.items():
-                if handle is None:
-                    self._register_hook_impl(m, hook_fn)
-
-    def _disable_group_hooks(self, group: str):
-        for m, hook_fn_to_handle in self.hook_functions[group].items():
-            for hook_fn, handle in hook_fn_to_handle.items():
-                if handle is not None:
-                    handle.remove()
-                    self.hook_functions[group][m][hook_fn] = None
-
-    def _flush_pipeline(self) -> None:
-        """Gather tensors from all pipeline stages to the first stage."""
-        if (
-            torch.distributed.is_initialized()
-            and dist.in_pipeline_parallel_group()
-            and dist.get_activation_pipeline_parallel_world_size() > 1
-        ):
-            gathered_acts = dist.gather_pipeline_parallel_tensor_dicts(self.output_ptr)
-
-            # Rank 0 accumulates the activation tensors.
-            if dist.get_activation_pipeline_parallel_rank() == 0:
-                self.output_ptr.update(gathered_acts)
-
-            # Other ranks reset their collections for the next forward pass.
-            else:
-                self.output_ptr = {}
-
-    def forward(self, *args, _group: str = "all", **kwargs) -> Any:
-        """Run a forward pass of the model with hooks enabled by default."""
-        # TODO: Extend for group pattern matching.
-        self._enable_group_hooks(_group)
-
-        outputs = self.module(*args, **kwargs)
-
-        # Post-forward cleanup.
-        self._flush_pipeline()
-
-        return outputs
+        self._register_hook_prologue(hook_function, "backward_pre")
 
     def register_trainable_module(self, name: str, module: nn.Module) -> None:
         """Register trainable module accessible to all :class:`HookFunction` instances.
@@ -423,3 +682,8 @@ class FlexModel(nn.Module):
         :rtype: List[str]
         """
         return self.wrapped_module_names + self.trainable_module_names
+
+    def restore(self) -> nn.Module:
+        """Cleans up dangling states and modifications to wrapped module."""
+        self._finalizer()
+        return self.module

--- a/tests/core/test_hook_function_group_manager.py
+++ b/tests/core/test_hook_function_group_manager.py
@@ -1,0 +1,203 @@
+import pytest
+
+from flex_model.core import HookFunction
+from flex_model.core.wrapper import _HookFunctionGroupManager
+from tests.fixtures import opt_350m_module_names
+
+
+def test_HookFunctionGroupManager_create(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    new_hook_fns = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+    new_hook_fns = set(new_hook_fns)
+
+    assert "new_group" in manager.groups
+
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if hook_fn in new_hook_fns:
+            assert "new_group" in groups
+            assert "self_attn" in hook_fn.module_name
+        else:
+            assert "new_group" not in groups
+            assert "self_attn" not in hook_fn.module_name
+
+
+def test_HookFunctionGroupManager_update_by_list(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    original_hf_group = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+    new_hf_group = [hf for hf in original_hf_group if "q_proj" in hf.module_name]
+
+    manager.update(
+        new_hf_group, group_name="q_proj",
+    )
+
+    assert "new_group" in manager.groups
+    assert "q_proj" in manager.groups
+
+    original_hf_group = set(original_hf_group)
+    new_hf_group = set(new_hf_group)
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if hook_fn in original_hf_group:
+            assert "new_group" in groups
+            assert "self_attn" in hook_fn.module_name
+        else:
+            assert "new_group" not in groups
+            assert "self_attn" not in hook_fn.module_name
+
+        if hook_fn in new_hf_group:
+            assert "q_proj" in groups
+            # Don't assert "q_proj" in module name since test does this.
+        else:
+            assert "q_proj" not in groups
+
+
+def test_HookFunctionGroupManager_update_by_hook_fn(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    hook_function = HookFunction("model.decoder.layers.12", (None, None, None),)
+
+    manager.update(hook_function, group_name="new_group")
+
+    assert "new_group" in manager.groups
+
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if hook_fn is hook_function:
+            assert "new_group" in groups
+        else:
+            assert "new_group" not in groups
+
+
+def test_HookFunctionGroupManager_update_by_string(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    new_hf_group = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    manager.update(
+        "k_proj", group_name="k_proj_group",
+    )
+
+    assert "new_group" in manager.groups
+    assert "k_proj_group" in manager.groups
+
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if hook_fn in new_hf_group:
+            assert "new_group" in groups
+        else:
+            assert "new_group" not in groups
+
+        if "k_proj" in hook_fn.module_name:
+            assert "k_proj_group" in groups
+        else:
+            assert "k_proj_group" not in groups
+
+
+def test_HookFunctionGroupManager_remove_by_list(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    new_hf_group = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+    other_hf_group = manager.create(
+        "other_group", "q_proj", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    assert "new_group" in manager.groups
+    assert "other_group" in manager.groups
+
+    manager.remove(new_hf_group, "new_group")
+
+    assert "new_group" not in manager.groups
+
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if hook_fn in new_hf_group:
+            assert "new_group" not in groups
+            assert "other_group" not in groups
+        else:
+            assert "other_group" in groups
+            assert "new_group" not in groups
+
+
+def test_HookFunctionGroupManager_remove_by_hook_fn(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    new_hf_group = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+    hf_to_remove = new_hf_group[0]
+
+    other_hf_group = manager.create(
+        "other_group", "q_proj", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    manager.remove(hf_to_remove, "new_group")
+
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if hook_fn is hf_to_remove:
+            assert "new_group" not in groups
+            assert "other_group" not in groups
+            continue
+
+        if hook_fn in new_hf_group:
+            assert "new_group" in groups
+            assert "other_group" not in groups
+        else:
+            assert "other_group" in groups
+            assert "new_group" not in groups
+
+
+def test_HookFunctionGroupManager_remove_by_string(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    new_hf_group = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    other_hf_group = manager.create(
+        "other_group", "q_proj", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    assert "new_group" in manager.groups
+    assert "other_group" in manager.groups
+
+    manager.remove("k_proj", "new_group")
+
+    for hook_fn, groups in manager.hook_fn_to_groups_map.items():
+        if "k_proj" in hook_fn.module_name:
+            assert "new_group" not in groups
+            assert "other_group" not in groups
+        else:
+            if hook_fn in new_hf_group:
+                assert "new_group" in groups
+                assert "other_group" not in groups
+            else:
+                assert "new_group" not in groups
+                assert "other_group" in groups
+
+
+def test_HookFunctionGroupManager_bisect(opt_350m_module_names):
+    manager = _HookFunctionGroupManager()
+
+    new_hf_group = manager.create(
+        "new_group", "self_attn", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    other_hf_group = manager.create(
+        "other_group", "fc1", (None, None, None), all_names=opt_350m_module_names,
+    )
+
+    active, inactive = manager.bisect("new_group")
+
+    assert active.isdisjoint(inactive)
+    assert set(other_hf_group) & inactive == inactive
+
+    active, inactive = manager.bisect(["new_group", "other_group"])
+
+    assert active.isdisjoint(inactive)
+    assert inactive == set()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,6 +40,14 @@ def opt_350m() -> nn.Module:
     return model
 
 
+@pytest.fixture(scope="session")
+def opt_350m_module_names():
+    model = AutoModelForCausalLM.from_pretrained(
+        "/model-weights/opt-350m", local_files_only=True, torch_dtype=torch.bfloat16,
+    )
+    return [n for n, _ in model.named_modules()]
+
+
 @pytest.fixture
 def opt_tokenizer():
     tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
This PR adds support for creating groups of `HookFunctions`. Users can provide a list of group names when generating activation tensors during forward/backwards passes, and the union of the `HookFunction`s associated with the groups will be activated while others are inactive.

These groups can be created by passing existing `HookFunction` instances to be associated with a group tag. They can also be created automatically by pattern-matching a string to the module/parameter name to be hooked into. There is also a new function in `FlexModel` which allows bulk `HookFunction` instantiation (using the same string patter-matching) and automatic group tagging.