### PR TITLE
Added strategies and cached state management

### DIFF
--- a/flex_model/distributed/cached_state.py
+++ b/flex_model/distributed/cached_state.py
@@ -1,0 +1,84 @@
+from torch import Tensor
+import torch.nn as nn
+
+from flex_model.distributed.distributed_state import _ParallelStateAPI
+from flex_model.distributed.stratgies import (
+    SaveCtxStrategy,
+    TrainableModulesStrategy,
+)
+
+
+def pipeline_sync(obj_to_sync, fmps: _ParallelStateAPI):
+    raise NotImplementedError
+
+
+class SaveContext:
+    def __init__(
+        self,
+        fmps: _ParallelStateAPI,
+        strategy: SaveCtxStrategy = SaveCtxStrategy.REPLICATE_ALL,
+    ):
+        self.strategy = strategy
+        self.fmps = fmps
+
+    def save(self, *tensors: Tensor):
+        for t in tensors:
+            assert isinstance(t, Tensor), (
+                "The `save` function should only be used on tensor instances. ",
+                "Non-tensor data can be saved using `save_ctx.data = item.",
+            )
+
+        # Don't cache tensors depending on strategy.
+        # dp_rank = self.fmps.get_data_parallel_rank()
+        # pp_rank = self.fmps.get_pipeline_parallel_rank()
+        # tp_rank = self.fmps.get_tensor_parallel_rank()
+
+        # Check if this rank should actually cache tensors.
+        do_cache_tensors = True
+        if self.strategy != SaveCtxStrategy.REPLICATE_ALL:
+            if self.strategy == SaveCtxStrategy.REPLICATE_PP:
+                raise NotImplementedError(
+                    "Passing save context along pipeline ranks is not "
+                    "implemented."
+                )
+
+        # Cache tensors if necessary.
+        if do_cache_tensors is True:
+            self.cached_tensors = tensors
+
+    def get_cached_tensors(self):
+        return self.cached_tensors
+
+    def sync(self):
+        # Check if we need to sync
+        do_sync = False
+        if self.strategy == SaveCtxStrategy.REPLICATE_ALL:
+            do_sync = True
+
+        # Sync if necessary.
+        if do_sync is True:
+            pipeline_sync(self._modules, self.fmps)
+        do_sync = False
+
+
+class TrainableModules(nn.ModuleDict):
+    def __init__(
+        self,
+        fmps: _ParallelStateAPI,
+        *args,
+        strategy: TrainableModulesStrategy = TrainableModulesStrategy.REPLICATE_ALL,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.strategy = strategy
+        self.fmps = fmps
+
+    def sync(self):
+        # Check if we need to sync
+        do_sync = False
+        if self.strategy == TrainableModulesStrategy.REPLICATE_ALL:
+            do_sync = True
+
+        # Sync if necessary.
+        if do_sync is True:
+            pipeline_sync(self._modules, self.fmps)

--- a/flex_model/distributed/strategies.py
+++ b/flex_model/distributed/strategies.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
 from torch import Tensor
@@ -279,3 +280,27 @@ class NonValidatedFunctionStrategy(BaseFunctionStrategy):
             return cls(user_func)
         else:
             raise Exception("Provided editing function is not valid")
+
+
+class SaveCtxStrategy(Enum):
+    """
+    Defines a strategy which handles allocating `save_ctx` data. Default
+    stratgy is to simply replicate all `save_ctx` across all workers.
+    """
+
+    REPLICATE_ALL = 1
+    REPLICATE_DP = 2
+    REPLICATE_PP = 3
+    REPLICATE_TP = 4
+
+
+class TrainableModulesStrategy(Enum):
+    """
+    Defines a strategy which handles allocating `trainable_modules`.
+    Default stratgy is to simply replicate across all workers.
+    """
+
+    REPLICATE_ALL = 1
+    REPLICATE_DP = 2
+    REPLICATE_PP = 3
+    REPLICATE_TP = 4


### PR DESCRIPTION
This PR ads strategy options for handling the `save_ctx` and `trainable_modules` cached state, exposed within each `HookFunction`'s `editing_function` runtime.